### PR TITLE
fix: SourceMapConsumer 在 0.7.x 版本后返回为一个 Promise 而不再是一个实例

### DIFF
--- a/wrap.js
+++ b/wrap.js
@@ -68,14 +68,16 @@ module.exports = function(file, opts) {
           new SourceMap.SourceMapConsumer(code_map.map.toJSON()).then(smp => {
             const generater = SourceMap.SourceMapGenerator.fromSourceMap(smp);
             sourcemap.setContent(generater.toString());
-            // file.setContent(content);
+            file.setContent(content);
           });
         }));
       } catch (e) {
         fis.log.warn('SourceMap Merge Error: %s\n%s', e.message, e.stack);
+        file.setContent(content);
       }
+    } else {
+      file.setContent(content);
     }
 
-    file.setContent(content);
   }
 }

--- a/wrap.js
+++ b/wrap.js
@@ -1,20 +1,21 @@
+const SourceMap = require('source-map');
+
 module.exports = function(file, opts) {
   // 不是 js 文件不处理。
   if (!file.isJsLike || file.isPartial) {
     return;
   }
 
-  var content = file.getContent();
-  var forceNoWrap = file.wrap === false;
-  
+  let content = file.getContent();
+  const forceNoWrap = file.wrap === false;
+
   if (!forceNoWrap && file.isMod) {
-    
-    var deps = '';
+    let deps = '';
     if (opts.forwardDeclaration) {
-      var reqs = opts.skipBuiltinModules ? [] : ['\'require\'', '\'exports\'', '\'module\''];
+      const reqs = opts.skipBuiltinModules ? [] : ['\'require\'', '\'exports\'', '\'module\''];
 
       file.requires.forEach(function(id) {
-        var dep = fis.uri(id, file.dirname);
+        const dep = fis.uri(id, file.dirname);
         if (dep.file) {
           if (dep.file.isJsLike) {
             reqs.push('\'' + (dep.file.moduleId || dep.file.id) + '\'');
@@ -27,14 +28,14 @@ module.exports = function(file, opts) {
       deps = ' [' + reqs.join(', ') + '],';
     }
 
-    var originContent = content;
+    const originContent = content;
 
     if (opts.tab) {
       content = fis.util.pad(' ', opts.tab) + content.split(/\n|\r\n|\r/g).join('\n' + fis.util.pad(' ', opts.tab));
     }
 
-    var prefix = 'define(\'' + (file.moduleId || file.id) + '\',' + deps + ' function(require, exports, module) {\n\n';
-    var affix = '\n\n});\n';
+    const prefix = 'define(\'' + (file.moduleId || file.id) + '\',' + deps + ' function(require, exports, module) {\n\n';
+    const affix = '\n\n});\n';
 
     content = prefix + content + affix;
 
@@ -43,32 +44,33 @@ module.exports = function(file, opts) {
     }
 
     // 同时修改 sourcemap 文件内容。
-    var derived = file.derived;
+    const derived = file.derived;
     if (!derived || !derived.length) {
       derived = file.extras && file.extras.derived;
     }
 
     if (derived && derived[0] && derived[0].rExt === '.map') {
       try {
-        var SourceMap = require('source-map');
-      
+        const sourcemap = derived[0];
+        const json = JSON.parse(sourcemap.getContent());
 
-        var sourcemap = derived[0];
-        var json = JSON.parse(sourcemap.getContent());
-        var smc = new SourceMap.SourceMapConsumer(json);
+        new SourceMap.SourceMapConsumer(json).then((smc => {
+          const sourceNode = new SourceMap.SourceNode();
 
-        var sourceNode = new SourceMap.SourceNode();
+          sourceNode.add(prefix);
+          sourceNode.add(SourceMap.SourceNode.fromStringWithSourceMap(originContent, smc));
+          sourceNode.add(affix);
 
-        sourceNode.add(prefix);
-        sourceNode.add(SourceMap.SourceNode.fromStringWithSourceMap(originContent, smc));
-        sourceNode.add(affix);
+          const code_map = sourceNode.toStringWithSourceMap({
+            file: smc.file
+          });
 
-        var code_map = sourceNode.toStringWithSourceMap({
-          file: smc.file
-        });
-
-        var generater = SourceMap.SourceMapGenerator.fromSourceMap(new SourceMap.SourceMapConsumer(code_map.map.toJSON()));
-        sourcemap.setContent(generater.toString());
+          new SourceMap.SourceMapConsumer(code_map.map.toJSON()).then(smp => {
+            const generater = SourceMap.SourceMapGenerator.fromSourceMap(smp);
+            sourcemap.setContent(generater.toString());
+            // file.setContent(content);
+          });
+        }));
       } catch (e) {
         fis.log.warn('SourceMap Merge Error: %s\n%s', e.message, e.stack);
       }


### PR DESCRIPTION
如题，sourcemap 0.7.x 版本存在破坏性更新